### PR TITLE
Allow switching HiveServer2 between using Tez and Map-Reduce

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,16 @@ hive-dist.tar.gz:
 
 dist: dist-tez dist-hive
 
+tez-hiveserver-on:
+	@cp startHiveserver2.sh.on /tmp/startHiveserver2.sh
+	@echo "HiveServer2 will now run jobs using Tez."
+	@echo "Reboot the Sandbox for changes to take effect."
+
+tez-hiveserver-off:
+	@cp startHiveserver2.sh.off /tmp/startHiveserver2.sh
+	@echo "HiveServer2 will now run jobs using Map-Reduce."
+	@echo "Reboot the Sandbox for changes to take effect."
+
 install: tez-dist.tar.gz hive-dist.tar.gz
 	-- mkdir -p /opt/tez/conf
 	tar -C /opt/tez/ -xzvf tez-dist.tar.gz

--- a/hive-site.xml.frag
+++ b/hive-site.xml.frag
@@ -2,4 +2,8 @@
     <name>hive.optimize.tez</name>
     <value>true</value>
   </property>
+  <property>
+    <name>javax.jdo.option.ConnectionPassword</name>
+    <value>hive</value>
+  </property>
 </configuration>

--- a/startHiveserver2.sh.off
+++ b/startHiveserver2.sh.off
@@ -1,0 +1,22 @@
+#
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#
+HIVE_CONF_DIR=$4 /usr/lib/hive/bin/hiveserver2 -hiveconf hive.metastore.uris=' ' > $1 2> $2 &
+echo $!|cat>$3

--- a/startHiveserver2.sh.on
+++ b/startHiveserver2.sh.on
@@ -1,0 +1,22 @@
+#
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#
+export HIVE_HOME=/opt/hive
+$HIVE_HOME/bin/hiveserver2 -hiveconf hive.metastore.uris=' ' > $1 2> $2 &

--- a/startMetastore.sh.off
+++ b/startMetastore.sh.off
@@ -1,0 +1,22 @@
+#
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#
+HIVE_CONF_DIR=$4 hive --service metastore > $1 2> $2 &
+echo $!|cat>$3

--- a/startMetastore.sh.on
+++ b/startMetastore.sh.on
@@ -1,0 +1,23 @@
+#
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#
+export HIVE_HOME=/opt/hive
+$HIVE_HOME/bin/hive --service metastore > $1 2> $2 &
+echo $!|cat>$3


### PR DESCRIPTION
Hey Gopal, I added a feature to allow a user to switch HiveServer2 to use Tez. Unfortunately I couldn't get HUE / Beeswax to use Tez so I've disabled that for now. Still it will be useful for tools like Tableau.
